### PR TITLE
Removed ineffective ``prec`` argument (sva)

### DIFF
--- a/src/SpringEstimator.cpp
+++ b/src/SpringEstimator.cpp
@@ -340,7 +340,7 @@ double SpringEstimator::update1Arm(double timeStep, int nrIter)
     // minimize distance between the arm 0 end effector and the target
     const sva::PTransformd& arm0 =
         arms_[0].mbc.bodyPosW[arms_[0].endEffectorIndex];
-    tasks_[0].err.noalias() = sva::rotationError(target_, arm0.rotation(), 1e-7);
+    tasks_[0].err.noalias() = sva::rotationError(target_, arm0.rotation());
     tasks_[0].jac.block(0, 0, 3, arms_[0].jac.dof()).noalias() =
         arms_[0].jacMat.block(0, 0, 3, arms_[0].jac.dof());
 
@@ -387,7 +387,7 @@ double SpringEstimator::updateNArm(double timeStep, int nrIter)
       tasks_[0].err.segment((i-1)*3, 3).noalias() =
           arm0.translation() - armi.translation();
       tasks_[1].err.segment((i-1)*3, 3).noalias() =
-          sva::rotationError(armi.rotation(), arm0.rotation(), 1e-7);
+          sva::rotationError(armi.rotation(), arm0.rotation());
 
       tasks_[0].jac.block((i-1)*3, 0, 3, arms_[0].jac.dof()).noalias() =
           arms_[0].jacMat.block(3, 0, 3, arms_[0].jac.dof());
@@ -404,7 +404,7 @@ double SpringEstimator::updateNArm(double timeStep, int nrIter)
     // minimize distance between the arm 0 end effector and the target
     const sva::PTransformd& arm0 =
         arms_[0].mbc.bodyPosW[arms_[0].endEffectorIndex];
-    tasks_[2].err.noalias() = sva::rotationError(target_, arm0.rotation(), 1e-7);
+    tasks_[2].err.noalias() = sva::rotationError(target_, arm0.rotation());
     tasks_[2].jac.block(0, 0, 3, arms_[0].jac.dof()).noalias() =
         arms_[0].jacMat.block(0, 0, 3, arms_[0].jac.dof());
 

--- a/tests/SpringEstimatorTest.cpp
+++ b/tests/SpringEstimatorTest.cpp
@@ -73,11 +73,11 @@ void testEndEffectors(const rbd::MultiBodyConfig& mbc1, const rbd::MultiBodyConf
   BOOST_CHECK_SMALL((mbc1.bodyPosW[endEffectorIndex].translation() -
                      mbc2.bodyPosW[endEffectorIndex].translation()).norm(), tol);
   BOOST_CHECK_SMALL(sva::rotationError(mbc1.bodyPosW[endEffectorIndex].rotation(),
-                    mbc2.bodyPosW[endEffectorIndex].rotation(), 1e-7).norm(), tol);
+                    mbc2.bodyPosW[endEffectorIndex].rotation()).norm(), tol);
   BOOST_CHECK_SMALL(sva::rotationError(mbc1.bodyPosW[endEffectorIndex].rotation(),
-                    target, 1e-7).norm(), tol);
+                    target).norm(), tol);
   BOOST_CHECK_SMALL(sva::rotationError(mbc2.bodyPosW[endEffectorIndex].rotation(),
-                    target, 1e-7).norm(), tol);
+                    target).norm(), tol);
 }
 
 
@@ -178,7 +178,7 @@ BOOST_AUTO_TEST_CASE(SpringEstimatorTest)
   rbd::vectorToParam(est.q().segment(0, 2), mbcLeft.q);
   rbd::forwardKinematics(mbLeft, mbcLeft);
   BOOST_CHECK_SMALL(sva::rotationError(mbcLeft.bodyPosW[3].rotation(),
-                    est.target(), 1e-7).norm(), 1e-6);
+                    est.target()).norm(), 1e-6);
 }
 
 
@@ -364,5 +364,5 @@ BOOST_AUTO_TEST_CASE(SpringEstimatorTestPrism)
   rbd::vectorToParam(est.q().segment(0, 3), mbcLeft.q);
   rbd::forwardKinematics(mbLeft, mbcLeft);
   BOOST_CHECK_SMALL(sva::rotationError(mbcLeft.bodyPosW[3].rotation(),
-                    est.target(), 1e-7).norm(), 1e-6);
+                    est.target()).norm(), 1e-6);
 }


### PR DESCRIPTION
Follows from jrl-umi3218/SpaceVecAlg#26